### PR TITLE
fix crash in unigram model training

### DIFF
--- a/src/unigram_model_trainer.cc
+++ b/src/unigram_model_trainer.cc
@@ -273,7 +273,7 @@ TrainerModel::SentencePieces Trainer::MakeSeedSentencePiecesInternal() {
     for (node_int_type i = 0; i < node_num; ++i) {
       const node_int_type offset = SA[L[i]];
       const node_int_type len = D[i];
-      if (len <= 1) {
+      if (len <= 1 || offset >= array.size() || offset + len >= array.size()) {
         continue;
       }
       const char32 *begin = &array[offset];


### PR DESCRIPTION
cherry pick 0fe7add, was blasted away in https://github.com/pilleye/sentencepiece/commit/53de76561cfc149d3c01037f0595669ad32a5e7c